### PR TITLE
DOC: Add Citation File Format (CFF) file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,26 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: >-
+  ITKCleaver: An ITK module to wrap Cleaver
+  functionality for MultiMaterial Tetrahedral Meshing
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - orcid: 'https://orcid.org/0000-0001-9475-3756'
+    given-names: Matthew
+    family-names: McCormick
+    email: matt.mccormick@kitware.com
+    affiliation: 'Kitware, Inc'
+  - given-names: Jess
+    family-names: Tate
+    orcid: 'https://orcid.org/0000-0002-2934-1453'
+    affiliation: University of Utah
+  - given-names: Jean-Christophe
+    family-names: Fillion-Robin
+    email: jcfr@kitware.com
+    affiliation: 'Kitware, Inc'
+    orcid: 'https://orcid.org/0000-0002-9688-8950'


### PR DESCRIPTION
Built from:

  https://citation-file-format.github.io/cff-initializer-javascript/

More information:

  https://github.com/citation-file-format/citation-file-format

Authors based on the committers to the repository.
