### PR TITLE
Download cleaver from renamed upstream project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@
 *.app
 
 # Cleaver Repository
-Cleaver2
+Cleaver
 examples/.ipynb_checkpoints/
 examples/triangle_mesh.vtk
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,7 @@ endif()
 set(_itk_build_shared ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF)
 set(cleaver_GIT_REPOSITORY "https://github.com/SCIInstitute/Cleaver")
-set(cleaver_GIT_TAG "02ba7b5fda5578b348a1dd54fb1660ef6cc7faf2")
-# Add https://github.com/SCIInstitute/Cleaver/pull/122
-set(cleaver_GIT_REPOSITORY "https://github.com/thewtex/Cleaver2")
-set(cleaver_GIT_TAG "2a4d7406b760e7af9f3a0d1f97d6168ddde7d1c7")
+set(cleaver_GIT_TAG "bb1d7e0604171b52f4e2f3b64178860dde0e4a58")
 FetchContent_Declare(
   cleaver_lib
   GIT_REPOSITORY ${cleaver_GIT_REPOSITORY}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,9 +26,9 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 endif()
 set(_itk_build_shared ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF)
-set(cleaver_GIT_REPOSITORY "https://github.com/SCIInstitute/Cleaver2")
+set(cleaver_GIT_REPOSITORY "https://github.com/SCIInstitute/Cleaver")
 set(cleaver_GIT_TAG "02ba7b5fda5578b348a1dd54fb1660ef6cc7faf2")
-# Add https://github.com/SCIInstitute/Cleaver2/pull/122
+# Add https://github.com/SCIInstitute/Cleaver/pull/122
 set(cleaver_GIT_REPOSITORY "https://github.com/thewtex/Cleaver2")
 set(cleaver_GIT_TAG "2a4d7406b760e7af9f3a0d1f97d6168ddde7d1c7")
 FetchContent_Declare(
@@ -40,8 +40,8 @@ if(NOT cleaver_lib_POPULATED)
   FetchContent_Populate(cleaver_lib)
   add_subdirectory(${cleaver_lib_SOURCE_DIR}/src ${cleaver_lib_BINARY_DIR})
 endif()
-# Debugging / development, symlink Cleaver2 into the source tree
-#add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/Cleaver2/src)
+# Debugging / development, symlink Cleaver into the source tree
+#add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/Cleaver/src)
 set(BUILD_TESTING ${_itk_build_testing} CACHE BOOL "Build testing code" FORCE)
 set(BUILD_SHARED_LIBS ${_itk_build_shared})
 

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Overview
 
 An ITK module to wrap Cleaver functionality for MultiMaterial Tetrahedral Meshing.
 
-`Cleaver <https://github.com/SCIInstitute/Cleaver2/releases>`_ is a free multimaterial tetrahedral meshing tool developed by the NIH Center for Integrative Biomedical Computing at the University of Utah Scientific Computing and Imaging (SCI) Institute.
+`Cleaver <https://github.com/SCIInstitute/Cleaver/releases>`_ is a free multimaterial tetrahedral meshing tool developed by the NIH Center for Integrative Biomedical Computing at the University of Utah Scientific Computing and Imaging (SCI) Institute.
 
 Acknowledgments
 ---------------

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:emscripten:debug": "itk-wasm -i itkwasm/emscripten:20230328-71e6501e-debug build -- -DCMAKE_BUILD_TYPE:STRING=Debug",
     "build:wasi": "itk-wasm -i itkwasm/wasi:20230328-71e6501e build",
     "build:wasi:debug": "itk-wasm -i itkwasm/wasi:20230328-71e6501e-debug build -- -DCMAKE_BUILD_TYPE:STRING=Debug",
-    "bindgen:typescript": "itk-wasm -b emscripten-build bindgen --output-dir wasm/typescript --package-name @itk-wasm/cleaver --package-description \"The Cleaver multimaterial tetrahedral meshing tool.\" --repository 'https://github.com/SCIInstitute/Cleaver2'",
+    "bindgen:typescript": "itk-wasm -b emscripten-build bindgen --output-dir wasm/typescript --package-name @itk-wasm/cleaver --package-description \"The Cleaver multimaterial tetrahedral meshing tool.\" --repository 'https://github.com/SCIInstitute/Cleaver'",
     "test": "npm run test:wasi",
     "test:wasi": "itk-wasm test --test-dir wasm",
     "clean": "git clean -fdx -e node_modules"

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     package_dir={'itk': 'itk'},
     download_url=r'https://github.com/SCIInstitute/ITKCleaver',
     description=r'An ITK interface to the Cleaver multi-material tetrahedral meshing library',
-    long_description='Cleaver2 ( https://github.com/SCIInstitute/Cleaver2/releases) is a free multimaterial tetrahedral meshing tool developed by the NIH Center for Integrative Biomedical Computing at the University of Utah Scientific Computing and Imaging (SCI) Institute.',
+    long_description='Cleaver ( https://github.com/SCIInstitute/Cleaver/releases) is a free multimaterial tetrahedral meshing tool developed by the NIH Center for Integrative Biomedical Computing at the University of Utah Scientific Computing and Imaging (SCI) Institute.',
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3",

--- a/wasm/typescript/package.json
+++ b/wasm/typescript/package.json
@@ -66,6 +66,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/SCIInstitute/Cleaver2"
+    "url": "https://github.com/SCIInstitute/Cleaver"
   }
 }


### PR DESCRIPTION
The table describes the renaming of the Cleaver 1 and Cleaver 2 GitHub repositories:

|             | From July 2013 to April 2023 | Since April 2023        |
|-------------|------------------------------|-------------------------|
| Cleaver 1.x | `SCIInstitute/Cleaver`       | `SCIInstitute/Cleaver1` |
| Cleaver 2.x | `SCIInstitute/Cleaver2`      | `SCIInstitute/Cleaver`  |

Source: https://github.com/SCIInstitute/Cleaver1#readme