### PR TITLE
Bump cleaver version

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -1,6 +1,14 @@
 name: Build, test, package
 
-on: [push,pull_request]
+on:
+  push:
+    branches:
+      - master
+    tags:
+       - '*'
+  pull_request:
+    branches:
+      - master
 
 jobs:
   cxx-build-workflow:

--- a/.github/workflows/clang-format-linter.yml
+++ b/.github/workflows/clang-format-linter.yml
@@ -1,6 +1,14 @@
 name: clang-format linter
 
-on: [push,pull_request]
+on:
+  push:
+    branches:
+      - master
+    tags:
+       - '*'
+  pull_request:
+    branches:
+      - master
 
 jobs:
   lint:

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,6 +1,14 @@
 name: WebAssembly
 
-on: [push,pull_request]
+on:
+  push:
+    branches:
+      - master
+    tags:
+       - '*'
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build-wasm:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 set(_itk_build_shared ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF)
 set(cleaver_GIT_REPOSITORY "https://github.com/SCIInstitute/Cleaver")
-set(cleaver_GIT_TAG "bb1d7e0604171b52f4e2f3b64178860dde0e4a58")
+set(cleaver_GIT_TAG "7b68a58b1c140fc56d3e39992a5c8dcdeb12c55e")
 FetchContent_Declare(
   cleaver_lib
   GIT_REPOSITORY ${cleaver_GIT_REPOSITORY}


### PR DESCRIPTION
* Avoid triggering GitHub Actions workflow on both upstream and fork
* Bump Cleaver version to integrate build-system updates

---

See https://github.com/SCIInstitute/cleaver/compare/bb1d7e060...7b68a58b1

List of changes:

```
$ git shortlog bb1d7e060..7b68a58b1 --no-merges
Jean-Christophe Fillion-Robin (32):
      ENH: Add GitHub workflow configuration for testing on macOS, Ubuntu and Windows
      COMP: Fix initialization of build-type to support multi-config CMake generator
      COMP: Update GitHub workflow to install Qt5 and build Cleaver GUI
      COMP: Set CMAKE_POSITION_INDEPENDENT_CODE instead of specifying -fPIC flag
      COMP: Set CMAKE_CXX_STANDARD instead of specifying -std=c++11 flag
      COMP: Remove obsolete CMake commands from Cleaver GUI CMakeLists.txt
      COMP: Consistently glob all headers and sources in Cleaver GUI CMakeLists.txt
      COMP: Simplify Qt5 integration looking up Qt5 module
      COMP: Fix macOS GitHub Actions workflow using current macos-11 image
      DOC: Improve README adding Overview/Method/Documentation/Authors/Acknowledgment/Citing
      DOC: Remove empty & unused "Indices and tables" section
      DOC: Improve "Authors" section
      DOC: Rename "Cleaver2" to "Cleaver" in docstrings and manual
      ENH: Rename "Cleaver2" to "Cleaver" in CLI and GUI applications
      ENH: Update obsolete documentation URL in GUI application About dialog
      DOC: Fix documentation build warnings
      DOC: Update conf.py updating comments
      DOC: Ensure Copyright year reported in generated documentation is current
      DOC: Cleanup requirements.txt
      DOC: Update Cleaver bibliography
      DOC: Ensure Cleaver is referenced consistently
      DOC: Convert index from reStructuredText to MyST Markdown
      STYLE: Update .gitignore to ensure only exclude top-level build directories
      DOC: Remove "layout.html" template not supported by "furo" theme
      DOC: Re-organize documentation
      DOC: Improve ITK build instructions
      DOC: Simplify build instructions using Qt5_DIR and referencing Qt 5.15.2
      DOC: Update build instructions
      DOC: Migrate Read the Docs settings to file and switch from python 3.7 to 3.9
      COMP: Simplify CLIs build-system
      COMP: Fix build of Cleaver library in project directly adding Cleaver sources
      COMP: Fix build of Cleaver CLIs in project directly adding Cleaver sources

Jess Tate (2):
      DOC: Fix typo in contributor name
      DOC: Fix link referencing SCI Institute software page
```