### PR TITLE
COMP: Update CI, Python packaging, and CMake 4.x compatibility

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -12,11 +12,15 @@ on:
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@e885a99c2e34497c4c5c0c1428a269fb0aae7902
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.6
     with:
       warnings-to-ignore: "\"libcleaver.a.*has no symbols\" \"libitkcleaver.*has no symbols\""
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@e885a99c2e34497c4c5c0c1428a269fb0aae7902
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.6
+    with:
+      itk-wheel-tag: 'v5.4.5'
+      itk-python-package-tag: 'v5.4.5'
+      test-notebooks: false
     secrets:
       pypi_password: ${{ secrets.pypi_password }}

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -13,14 +13,14 @@ on:
 jobs:
   build-wasm:
     name: "build-test-wasm"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+    - uses: actions/checkout@v5
 
-    - uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65 # v4.0.0
+    - uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '22'
 
     - name: Install
       run: |
@@ -59,13 +59,13 @@ jobs:
         browser: firefox
         start: npm start
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: cypress-screenshots
         path: wasm/typescript/cypress/screenshots
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: cypress-videos

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,11 @@ if(DEFINED BUILD_TESTING)
 else()
   set(_itk_build_testing OFF) # Default
 endif()
-if(WASI OR EMSCRIPTEN)
-  # Cleaver lib vendored GTest incompatibility
-  set(BUILD_TESTING OFF CACHE BOOL "Build testing code" FORCE)
-endif()
+# Disable testing for the vendored Cleaver lib — its bundled googletest
+# (via CIBC-Internal/googletest ExternalProject) uses cmake_minimum_required
+# < 3.5 which CMake >= 4.0 rejects. The ITK module has its own tests.
+# Upstream fix: SCIInstitute/Cleaver#130
+set(BUILD_TESTING OFF CACHE BOOL "Build testing code" FORCE)
 if (CMAKE_CXX_COMPILER_IS_GNUCXX)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-maybe-uninitialized")
 endif()

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "type": "module",
   "scripts": {
     "build": "npm run build:emscripten && npm run build:wasi && npm run bindgen:typescript",
-    "build:emscripten": "itk-wasm -i itkwasm/emscripten:20230328-71e6501e build",
-    "build:emscripten:debug": "itk-wasm -i itkwasm/emscripten:20230328-71e6501e-debug build -- -DCMAKE_BUILD_TYPE:STRING=Debug",
-    "build:wasi": "itk-wasm -i itkwasm/wasi:20230328-71e6501e build",
-    "build:wasi:debug": "itk-wasm -i itkwasm/wasi:20230328-71e6501e-debug build -- -DCMAKE_BUILD_TYPE:STRING=Debug",
+    "build:emscripten": "itk-wasm -i itkwasm/emscripten:20250619-3165ade4 build",
+    "build:emscripten:debug": "itk-wasm -i itkwasm/emscripten:20250619-3165ade4-debug build -- -DCMAKE_BUILD_TYPE:STRING=Debug",
+    "build:wasi": "itk-wasm -i itkwasm/wasi:20250619-3165ade4 build",
+    "build:wasi:debug": "itk-wasm -i itkwasm/wasi:20250619-3165ade4-debug build -- -DCMAKE_BUILD_TYPE:STRING=Debug",
     "bindgen:typescript": "itk-wasm -b emscripten-build bindgen --output-dir wasm/typescript --package-name @itk-wasm/cleaver --package-description \"The Cleaver multimaterial tetrahedral meshing tool.\" --repository 'https://github.com/SCIInstitute/Cleaver'",
     "test": "npm run test:wasi",
     "test:wasi": "itk-wasm test --test-dir wasm",
@@ -16,6 +16,6 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "itk-wasm": "^1.0.0-b.91"
+    "itk-wasm": "^1.0.0-b.176"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "itk-cleaver"
-version = "1.4.0"
+version = "1.4.1"
 description = "An ITK interface to the Cleaver multi-material tetrahedral meshing library"
 readme = "README.rst"
 license = {file = "LICENSE"}
@@ -34,7 +34,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
     "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "itk == 5.4.*",
 ]


### PR DESCRIPTION
Consolidate all pending CI and packaging updates that restore ITKCleaver's buildability on current toolchains (CMake ≥ 4.0). Supersedes #63, #70, #72, #73, #74, #75.

The one red check — `build-test-wasm` — is **pre-existing** (it is also red on `master` at `3d0fd19`) and is **not** caused by this PR; see details below.

<details>
<summary>What's in this PR (4 commits)</summary>

1. Update CI workflows to latest action versions + ITK v5.4.6
2. Update itk-wasm build images to `20250619-3165ade4`
3. Bump version to 1.4.1 and require Python ≥ 3.10
4. Disable vendored Cleaver-lib testing for CMake 4.x compat (vendored googletest declares `cmake_minimum_required(VERSION <3.5)`, which CMake 4 hard-rejects; the ITK module keeps its own tests). Matches upstream fix SCIInstitute/Cleaver#130.

</details>

<details>
<summary>Status of the pre-existing wasm CI failure (updated)</summary>

The wasm job is red on `master` as well, so this is not a regression. With this PR's CI updates (newer itk-wasm build image), the failure mode has **shifted downstream**:

- The C++ `Build` and `Test WASI` steps now **pass** (the earlier `itkOverrideGetNameOfClassMacro`-style C++ break from the older Docker image no longer occurs).
- The failure is now in the **`Build TypeScript, JavaScript package`** step — `tsc` errors from an itk-wasm version skew between the bindgen output and the `itk-wasm` npm dependency:
  - `index-common.ts: TS2307: Cannot find module './version.js'`
  - two `TS7016` — worker `.min.worker.js` bundles lack `.d.ts`
  - `itk-cleaver.ts:76: TS2554: Expected 4-5 arguments, but got 6`

This PR does not touch any `wasm/typescript/src/*.ts`; resolving it requires aligning the bindgen image with the npm `itk-wasm` version (or committing regenerated bindings) — out of scope for this CMake-4 / packaging maintenance batch. Happy to split the CMake-4 hunk into a minimal standalone PR if that's easier to merge.

</details>

<!--
provenance: claude-code gh-triage-pr session 2026-06-18
head_sha: e6a55a119103266fd05675bd12fab751dfbe684e
ci: build-test-wasm red (pre-existing; master 3d0fd19 also red). C++ Build + Test WASI pass; failure now at "Build TypeScript, JavaScript package" step.
ts_errors: index-common.ts TS2307 ./version.js; index-worker-embedded(.min).ts TS7016; itk-cleaver.ts:76 TS2554 (6 args vs 4-5) — itk-wasm bindgen/npm version skew.
phase1_human: clean (only author comments, threads resolved). phase3_greptile: n/a.
post_merge_action: consider transferring ITKCleaver to InsightSoftwareConsortium org; revisit wasm TS binding regen separately.
-->
